### PR TITLE
Remove rules blocking Google reCAPTCHA

### DIFF
--- a/chromium/rulesets/main/annoyances-others.json
+++ b/chromium/rulesets/main/annoyances-others.json
@@ -431,8 +431,6 @@
 {"action":{"type":"block"},"condition":{"initiatorDomains":["spacenews.com"],"resourceTypes":["script"],"urlFilter":"||spacenews.com/wp-content/plugins/newspack-plugin/dist/content-gate-metering.js"},"id":430,"priority":10},
 {"action":{"type":"block"},"condition":{"resourceTypes":["media"],"urlFilter":"||cdn.24liveblog.com/audio/"},"id":431,"priority":10},
 {"action":{"type":"block"},"condition":{"urlFilter":"||predict-v4.getwair.com/default/predict.js"},"id":432,"priority":10},
-{"action":{"type":"block"},"condition":{"resourceTypes":["script","xmlhttprequest","sub_frame"],"urlFilter":"||gstatic.com/recaptcha/*"},"id":500,"priority":100},
-{"action":{"type":"block"},"condition":{"resourceTypes":["script","xmlhttprequest","sub_frame"],"urlFilter":"||google.com/recaptcha/*"},"id":501,"priority":100},
 {"action":{"type":"block"},"condition":{"excludedInitiatorDomains":["google.com","www.google.com","maps.google.com"],"resourceTypes":["script","xmlhttprequest","sub_frame"],"urlFilter":"||google.com/maps/*"},"id":502,"priority":100},
 {"action":{"type":"block"},"condition":{"resourceTypes":["script","xmlhttprequest","sub_frame"],"urlFilter":"||forms.hsforms.com/*"},"id":503,"priority":100}
 ]


### PR DESCRIPTION
## Summary
- Remove the two custom webmonitoring rules (ids 500 and 501) from `chromium/rulesets/main/annoyances-others.json` that blocked `||gstatic.com/recaptcha/*` and `||google.com/recaptcha/*`

These were webmonitoring-specific additions, not upstream uBOL filters. The adjacent Google Maps (id 502) and hsforms (id 503) rules are untouched. Firefox rulesets never had these rules, so no change needed there.

Merging to `wm/patches` will trigger the `publish_chromium_package` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEfA9FQFSLeUPmvstGRMYV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated content filtering to allow Google reCAPTCHA resources to load, improving compatibility with websites that use reCAPTCHA verification.
  * Existing blocking rules for other Google services remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->